### PR TITLE
Setup deploy task for gh-pages and simplify loading of Grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-/* global module */
+/* global module, require */
 
 module.exports = function(grunt) {
     'use strict';
@@ -113,15 +113,19 @@ module.exports = function(grunt) {
                     expand: true
                 }]
             }
+        },
+
+        'gh-pages': {
+            options: {
+                base: 'dist',
+                message: 'Deploy to GitHub Pages'
+            },
+            src: ['**/*']
         }
 
     });
 
-    grunt.loadNpmTasks('grunt-contrib-copy');
-    grunt.loadNpmTasks('grunt-contrib-clean');
-    grunt.loadNpmTasks('grunt-contrib-jshint');
-    grunt.loadNpmTasks('grunt-jscs');
-    grunt.loadNpmTasks('grunt-contrib-watch');
+    require('load-grunt-tasks')(grunt);
 
     grunt.registerTask('default', ['build']);
     grunt.registerTask('check:failOnError', ['jshint:failOnError', 'jscs:failOnError']);
@@ -129,4 +133,5 @@ module.exports = function(grunt) {
     grunt.registerTask('check', ['check:failOnError']);
     grunt.registerTask('ci', ['default']);
     grunt.registerTask('build', ['check', 'clean', 'copy']);
+    grunt.registerTask('deploy', ['build', 'gh-pages']);
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "grunt-contrib-jasmine": "^0.9.0",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-jscs": "^1.8.0"
+    "grunt-gh-pages": "^0.10.0",
+    "grunt-jscs": "^1.8.0",
+    "load-grunt-tasks": "^3.2.0"
   }
 }


### PR DESCRIPTION
This allows a user to run `grunt deploy` which will automatically build and push the files in `dist` to the gh-pages branch of their repository.

I haven't integrated this with Travis yet, as it's only a one-step process to deploy and this allows more flexibility for what we deploy and when. If we want to automate with Travis, I can look into this.

See it in action here: http://jleft.github.io/d3fc-showcase/
(Repo: [jleft/gh-pages](https://github.com/jleft/d3fc-showcase/tree/gh-pages))