### PR TITLE
Disallow the user from scrolling past the beginning or end of the page content

### DIFF
--- a/mobile/config.xml
+++ b/mobile/config.xml
@@ -24,4 +24,5 @@
         <allow-intent href="itms-apps:*" />
     </platform>
     <icon src="res/icon.png" />
+    <preference name="DisallowOverscroll" value="true"/>
 </widget>


### PR DESCRIPTION
(In Android and iOS app)