### PR TITLE
Removed id from container as it seems misleading

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -2,7 +2,7 @@
     'use strict';
 
     // Set SVGs & column padding
-    var container = d3.select('#chart-example');
+    var container = d3.select('#app-container');
 
     var svgMain = container.select('svg.primary');
     var svgRSI = container.select('svg.rsi');

--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,7 @@
   </head>
   <body>
   
-    <div class="container" id="chart-example">
+    <div class="container" id="app-container">
 
       <div class="row" id="head-row">
         <div class="col-md-12">


### PR DESCRIPTION
Using the `chart-example` id for the container seems misleading now.