### PR TITLE
Integrate historic data

### DIFF
--- a/src/assets/js/data/feed/coinbase/historicFeed.js
+++ b/src/assets/js/data/feed/coinbase/historicFeed.js
@@ -2,7 +2,6 @@
     'use strict';
 
     sc.data.feed.coinbase.historicFeed = function() {
-        // In seconds - maybe take this out and have chart pass in a period whenever needed
         var feed = fc.data.feed.coinbase();
         var n = 0;
 

--- a/src/assets/js/data/feed/coinbase/historicFeed.js
+++ b/src/assets/js/data/feed/coinbase/historicFeed.js
@@ -1,0 +1,30 @@
+(function(sc) {
+    'use strict';
+
+    sc.data.feed.coinbase.historicFeed = function() {
+        // In seconds - maybe take this out and have chart pass in a period whenever needed
+        var feed = fc.data.feed.coinbase();
+        var n = 0;
+
+        function historicFeed(callback) {
+            var id = ++n;
+            feed(function(err, newData) {
+                if (id < n) { return; }
+                if (!err) {
+                    newData = newData.reverse();
+                    callback(null, newData);
+                } else { callback(err, null); }
+            });
+        }
+
+        d3.rebind(historicFeed, feed, 'granularity', 'start', 'end');
+
+        historicFeed.invalidateCallback = function() {
+            n++;
+            return historicFeed;
+        };
+
+        return historicFeed;
+    };
+
+})(sc);

--- a/src/assets/js/data/feed/coinbase/historicFeed.js
+++ b/src/assets/js/data/feed/coinbase/historicFeed.js
@@ -16,7 +16,7 @@
             });
         }
 
-        d3.rebind(historicFeed, feed, 'granularity', 'start', 'end');
+        d3.rebind(historicFeed, feed, 'granularity', 'start', 'end', 'product');
 
         historicFeed.invalidateCallback = function() {
             n++;

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -109,8 +109,7 @@
             var type = d3.select(this).property('value');
             if (type === 'live') {
                 historicFeed(historicCallback);
-                render();
-            } else if (type === 'fake') {
+            } else if (type === 'generated') {
                 historicFeed.invalidateCallback();
                 dataModel.data = fc.data.random.financial()(250);
                 resetToLive();

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -94,7 +94,7 @@
     var currDate = new Date();
     var startDate = d3.time.minute.offset(currDate, -199);
 
-    var coinbase = fc.data.feed.coinbase()
+    var historicFeed = sc.data.feed.coinbase.historicFeed()
         .granularity(60)
         .start(startDate)
         .end(currDate);
@@ -125,7 +125,7 @@
 
     function historicCallback(err, newData) {
         if (!err) {
-            data = newData.reverse();
+            data = newData;
             resetToLive();
             ohlcConverter(liveCallback);
             render();
@@ -144,12 +144,13 @@
             if (type === 'live') {
                 data = [];
                 toggleLiveFeedUI(true);
-                coinbase(historicCallback);
+                historicFeed(historicCallback);
                 render();
 
             } else if (type === 'fake') {
                 toggleLiveFeedUI(false);
                 ohlcConverter.close();
+                historicFeed.invalidateCallback();
                 data = fc.data.random.financial()(250);
                 resetToLive();
                 render();
@@ -224,32 +225,6 @@
             .call(navChart);
     }
 
-    var multi = fc.series.multi()
-        .series([gridlines, ma, currentSeries, closeAxisAnnotation])
-        .mapping(function(series) {
-            switch (series) {
-                case closeAxisAnnotation:
-                    return [data[data.length - 1]];
-                default:
-                    return data;
-            }
-        })
-        .key(function(series, index) {
-            switch (series) {
-                case line:
-                    return index;
-                default:
-                    return series;
-            }
-        });
-
-    function zoomCall(zoom, selection, data, scale) {
-        return function() {
-            sc.util.zoomControl(zoom, selection, data, scale);
-            render();
-        };
-    }
-    
     function resize() {
         sc.util.calculateDimensions(container);
         render();

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -101,10 +101,10 @@
         resetToLive();
         render();
     }
-        
+
     function historicCallback(err, newData) {
         if (!err) {
-            updateDataAndResetChart(newData)
+            updateDataAndResetChart(newData);
         } else { console.log('Error getting historic data: ' + err); }
     }
 
@@ -116,7 +116,7 @@
             } else if (type === 'generated') {
                 historicFeed.invalidateCallback();
                 var newData = fc.data.random.financial()(250);
-                updateDataAndResetChart(newData)
+                updateDataAndResetChart(newData);
             }
         });
 

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -92,7 +92,7 @@
         .period(60);
 
     var currDate = new Date();
-    var startDate = d3.time.minute.offset(currDate, -199);
+    var startDate = d3.time.minute.offset(currDate, -200);
 
     var historicFeed = sc.data.feed.coinbase.historicFeed()
         .granularity(60)
@@ -110,13 +110,11 @@
 
     function liveCallback(event, latestBasket) {
         if (!event && latestBasket) {
-            console.log(latestBasket);
             newBasketReceived(latestBasket);
         } else if (event.type === 'open') {
             // On successful open
-            console.log('Connected, waiting for data...');
         } else if (event.type === 'close' && event.code === 1000) {
-            // No need for a message on successful close
+            // On successful close
         } else {
             console.log('Error loading data from coinbase websocket: ' +
                 event.type + ' ' + event.code);
@@ -132,23 +130,13 @@
         } else { console.log('Error getting historic data: ' + err); }
     }
 
-    function toggleLiveFeedUI(visible) {
-        var visibility = (visible === true) ? 'visible' : 'hidden';
-        d3.select('#period-span').style('visibility', visibility);
-        d3.select('#product-span').style('visibility', visibility);
-    }
-
     d3.select('#type-selection')
         .on('change', function() {
             var type = d3.select(this).property('value');
             if (type === 'live') {
-                data = [];
-                toggleLiveFeedUI(true);
                 historicFeed(historicCallback);
                 render();
-
             } else if (type === 'fake') {
-                toggleLiveFeedUI(false);
                 ohlcConverter.close();
                 historicFeed.invalidateCallback();
                 data = fc.data.random.financial()(250);

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -104,7 +104,7 @@
 
     function historicCallback(err, newData) {
         if (!err) {
-            updateDataAndResetChart(newData);
+            updateDataAndResetChart(newData.reverse());
         } else { console.log('Error getting historic data: ' + err); }
     }
 

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -96,11 +96,15 @@
         .start(startDate)
         .end(currDate);
 
+    function updateDataAndResetChart(newData) {
+        dataModel.data = newData;
+        resetToLive();
+        render();
+    }
+        
     function historicCallback(err, newData) {
         if (!err) {
-            dataModel.data = newData;
-            resetToLive();
-            render();
+            updateDataAndResetChart(newData)
         } else { console.log('Error getting historic data: ' + err); }
     }
 
@@ -111,9 +115,8 @@
                 historicFeed(historicCallback);
             } else if (type === 'generated') {
                 historicFeed.invalidateCallback();
-                dataModel.data = fc.data.random.financial()(250);
-                resetToLive();
-                render();
+                var newData = fc.data.random.financial()(250);
+                updateDataAndResetChart(newData)
             }
         });
 

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -88,9 +88,6 @@
         onViewChanged(standardDateDisplay);
     }
 
-    var ohlcConverter = sc.data.feed.coinbase.ohlcWebSocketAdaptor()
-        .period(60);
-
     var currDate = new Date();
     var startDate = d3.time.minute.offset(currDate, -200);
 
@@ -99,33 +96,10 @@
         .start(startDate)
         .end(currDate);
 
-    function newBasketReceived(basket) {
-        if (data[data.length - 1].date.getTime() !== basket.date.getTime()) {
-            data.push(basket);
-        } else {
-            data[data.length - 1] = basket;
-        }
-        render();
-    }
-
-    function liveCallback(event, latestBasket) {
-        if (!event && latestBasket) {
-            newBasketReceived(latestBasket);
-        } else if (event.type === 'open') {
-            // On successful open
-        } else if (event.type === 'close' && event.code === 1000) {
-            // On successful close
-        } else {
-            console.log('Error loading data from coinbase websocket: ' +
-                event.type + ' ' + event.code);
-        }
-    }
-
     function historicCallback(err, newData) {
         if (!err) {
-            data = newData;
+            dataModel.data = newData;
             resetToLive();
-            ohlcConverter(liveCallback);
             render();
         } else { console.log('Error getting historic data: ' + err); }
     }
@@ -137,9 +111,8 @@
                 historicFeed(historicCallback);
                 render();
             } else if (type === 'fake') {
-                ohlcConverter.close();
                 historicFeed.invalidateCallback();
-                data = fc.data.random.financial()(250);
+                dataModel.data = fc.data.random.financial()(250);
                 resetToLive();
                 render();
             }
@@ -147,64 +120,9 @@
 
     container.select('#reset-button').on('click', resetToLive);
 
-    // Create main chart and set how much data is initially viewed
-    var timeSeries = fc.chart.linearTimeSeries()
-        .xTicks(6);
-
-    var gridlines = fc.annotation.gridline()
-        .yTicks(5)
-        .xTicks(0);
-
-    function calculateCloseAxisTagPath(width, height) {
-        var h2 = height / 2;
-        return [
-            [0, 0],
-            [h2, -h2],
-            [width, -h2],
-            [width, h2],
-            [h2, h2],
-            [0, 0]
-        ];
-    }
-
-    function positionCloseAxis(sel) {
-        sel.enter()
-            .select('.right-handle')
-            .insert('path', ':first-child')
-            .attr('transform', 'translate(' + -40 + ', 0)')
-            .attr('d', d3.svg.area()(calculateCloseAxisTagPath(40, 14)));
-
-        sel.select('text')
-            .attr('transform', 'translate(' + (-2) + ', ' + 2 + ')')
-            .attr('x', 0)
-            .attr('y', 0);
-    }
-
-    var priceFormat = d3.format('.2f');
-
-    var closeAxisAnnotation = fc.annotation.line()
-        .orient('horizontal')
-        .value(function(d) { return d.close; })
-        .label(function(d) { return priceFormat(d.close); })
-        .decorate(function(sel) {
-            positionCloseAxis(sel);
-            sel.enter().classed('close', true);
-        });
-
-    // Create and apply the Moving Average
-    var movingAverage = fc.indicator.algorithm.movingAverage();
-
-    // Create a line that renders the result
-    var ma = fc.series.line()
-        .decorate(function(selection) {
-            selection.enter()
-                .classed('ma', true);
-        })
-        .yValue(function(d) { return d.movingAverage; });
-
     function render() {
-        svgMain.datum(data)
-            .call(mainChart);
+        svgMain.datum(dataModel)
+            .call(primaryChart);
 
         svgRSI.datum(dataModel)
             .call(rsiChart);
@@ -222,5 +140,4 @@
 
     resetToLive();
     resize();
-
 })(d3, fc, sc);

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -86,14 +86,136 @@
         var standardDateDisplay = [data[Math.floor((1 - navAspect * goldenRatio) * data.length)].date,
             data[data.length - 1].date];
         onViewChanged(standardDateDisplay);
+    }
+
+    var ohlcConverter = sc.data.feed.coinbase.ohlcWebSocketAdaptor()
+        .period(60);
+
+    var currDate = new Date();
+    var startDate = d3.time.minute.offset(currDate, -199);
+
+    var coinbase = fc.data.feed.coinbase()
+        .granularity(60)
+        .start(startDate)
+        .end(currDate);
+
+    function newBasketReceived(basket) {
+        if (data[data.length - 1].date.getTime() !== basket.date.getTime()) {
+            data.push(basket);
+        } else {
+            data[data.length - 1] = basket;
+        }
         render();
     }
 
+    function liveCallback(event, latestBasket) {
+        if (!event && latestBasket) {
+            console.log(latestBasket);
+            newBasketReceived(latestBasket);
+        } else if (event.type === 'open') {
+            // On successful open
+            console.log('Connected, waiting for data...');
+        } else if (event.type === 'close' && event.code === 1000) {
+            // No need for a message on successful close
+        } else {
+            console.log('Error loading data from coinbase websocket: ' +
+                event.type + ' ' + event.code);
+        }
+    }
+
+    function historicCallback(err, newData) {
+        if (!err) {
+            data = newData.reverse();
+            resetToLive();
+            ohlcConverter(liveCallback);
+            render();
+        } else { console.log('Error getting historic data: ' + err); }
+    }
+
+    function toggleLiveFeedUI(visible) {
+        var visibility = (visible === true) ? 'visible' : 'hidden';
+        d3.select('#period-span').style('visibility', visibility);
+        d3.select('#product-span').style('visibility', visibility);
+    }
+
+    d3.select('#type-selection')
+        .on('change', function() {
+            var type = d3.select(this).property('value');
+            if (type === 'live') {
+                data = [];
+                toggleLiveFeedUI(true);
+                coinbase(historicCallback);
+                render();
+
+            } else if (type === 'fake') {
+                toggleLiveFeedUI(false);
+                ohlcConverter.close();
+                data = fc.data.random.financial()(250);
+                resetToLive();
+                render();
+            }
+        });
+
     container.select('#reset-button').on('click', resetToLive);
 
+    // Create main chart and set how much data is initially viewed
+    var timeSeries = fc.chart.linearTimeSeries()
+        .xTicks(6);
+
+    var gridlines = fc.annotation.gridline()
+        .yTicks(5)
+        .xTicks(0);
+
+    function calculateCloseAxisTagPath(width, height) {
+        var h2 = height / 2;
+        return [
+            [0, 0],
+            [h2, -h2],
+            [width, -h2],
+            [width, h2],
+            [h2, h2],
+            [0, 0]
+        ];
+    }
+
+    function positionCloseAxis(sel) {
+        sel.enter()
+            .select('.right-handle')
+            .insert('path', ':first-child')
+            .attr('transform', 'translate(' + -40 + ', 0)')
+            .attr('d', d3.svg.area()(calculateCloseAxisTagPath(40, 14)));
+
+        sel.select('text')
+            .attr('transform', 'translate(' + (-2) + ', ' + 2 + ')')
+            .attr('x', 0)
+            .attr('y', 0);
+    }
+
+    var priceFormat = d3.format('.2f');
+
+    var closeAxisAnnotation = fc.annotation.line()
+        .orient('horizontal')
+        .value(function(d) { return d.close; })
+        .label(function(d) { return priceFormat(d.close); })
+        .decorate(function(sel) {
+            positionCloseAxis(sel);
+            sel.enter().classed('close', true);
+        });
+
+    // Create and apply the Moving Average
+    var movingAverage = fc.indicator.algorithm.movingAverage();
+
+    // Create a line that renders the result
+    var ma = fc.series.line()
+        .decorate(function(selection) {
+            selection.enter()
+                .classed('ma', true);
+        })
+        .yValue(function(d) { return d.movingAverage; });
+
     function render() {
-        svgMain.datum(dataModel)
-            .call(primaryChart);
+        svgMain.datum(data)
+            .call(mainChart);
 
         svgRSI.datum(dataModel)
             .call(rsiChart);
@@ -102,6 +224,32 @@
             .call(navChart);
     }
 
+    var multi = fc.series.multi()
+        .series([gridlines, ma, currentSeries, closeAxisAnnotation])
+        .mapping(function(series) {
+            switch (series) {
+                case closeAxisAnnotation:
+                    return [data[data.length - 1]];
+                default:
+                    return data;
+            }
+        })
+        .key(function(series, index) {
+            switch (series) {
+                case line:
+                    return index;
+                default:
+                    return series;
+            }
+        });
+
+    function zoomCall(zoom, selection, data, scale) {
+        return function() {
+            sc.util.zoomControl(zoom, selection, data, scale);
+            render();
+        };
+    }
+    
     function resize() {
         sc.util.calculateDimensions(container);
         render();

--- a/src/index.html
+++ b/src/index.html
@@ -28,7 +28,7 @@
           </div>
           <div class="col-md-2">
             <select id="type-selection" selected="type" class="form-control">
-              <option value="fake">Data generator</option>
+              <option value="generated">Data generator</option>
               <option value="live">Live data</option>
             </select>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -26,6 +26,12 @@
           </div>
           <div id="indicator-buttons" class="btn-group" data-toggle="buttons">
           </div>
+          <div class="col-md-2">
+            <select id="type-selection" selected="type" class="form-control">
+              <option value="fake">Data generator</option>
+              <option value="live">Live data</option>
+            </select>
+          </div>
           <div class="pull-right">
             <div id="reset-button">
               <button class="btn btn-default" type="button">Reset</button>

--- a/src/index.html
+++ b/src/index.html
@@ -66,6 +66,7 @@
     <script src="assets/js/util/filterDataInDateRange.js"></script>
     <script src="assets/js/data/feed/coinbase/webSocket.js"></script>
     <script src="assets/js/data/feed/coinbase/ohlcWebSocketAdaptor.js"></script>
+    <script src="assets/js/data/feed/coinbase/historicFeed.js"></script>
     <script src="assets/js/chart/primaryChart.js"></script>
     <script src="assets/js/chart/rsiChart.js"></script>
     <script src="assets/js/chart/navChart.js"></script>


### PR DESCRIPTION
Added an option for basic historic data, no period/product selectors atm but they would be simple to add afterwards. This also makes it pretty simple to add in support for a live stream. There is a button to switch between 'live' and generated data, and a class for the historic feed which adds the ability to cancel a request that's been made (invalidateCallback)