### PR TITLE
Pad the xDomain of the primary chart so full candles can be seen at either extreme

### DIFF
--- a/src/assets/js/chart/macdChart.js
+++ b/src/assets/js/chart/macdChart.js
@@ -11,7 +11,7 @@
         function macdChart(selection) {
             var data = selection.datum().data;
             var domain = selection.datum().domain;
-            var currentBufferPeriod = selection.datum().displayBuffer ? selection.datum().dataPeriod : 0;
+            var currentBufferPeriod = selection.datum().displayBuffer ? selection.datum().period : 0;
             var paddedDomain = sc.util.paddedExtent(domain, currentBufferPeriod);
 
             macdAlgorithm(data);

--- a/src/assets/js/chart/macdChart.js
+++ b/src/assets/js/chart/macdChart.js
@@ -10,7 +10,9 @@
 
         function macdChart(selection) {
             var data = selection.datum().data;
-            var viewDomain = selection.datum().viewDomain;
+            var domain = selection.datum().domain;
+            var currentBufferPeriod = selection.datum().displayBuffer ? selection.datum().dataPeriod : 0;
+            var paddedDomain = sc.util.paddedExtent(domain, currentBufferPeriod);
 
             macdAlgorithm(data);
 
@@ -19,21 +21,14 @@
             });
 
             macd.xScale()
-                .domain(viewDomain)
+                .domain(paddedDomain)
                 .range([0, parseInt(selection.style('width'), 10)]);
             macd.yScale()
                 .domain([-maxYExtent, maxYExtent])
                 .range([parseInt(selection.style('height'), 10), 0]);
 
+            sc.util.applyZoom(selection, data, dispatch, domain);
 
-            var zoom = d3.behavior.zoom();
-            zoom.x(macd.xScale())
-                .on('zoom', function() {
-                    sc.util.zoomControl(zoom, selection, data, macd.xScale());
-                    dispatch.viewChange(macd.xScale().domain());
-                });
-
-            selection.call(zoom);
             selection.datum(data)
                 .call(macd);
         }

--- a/src/assets/js/chart/macdChart.js
+++ b/src/assets/js/chart/macdChart.js
@@ -27,7 +27,7 @@
                 .domain([-maxYExtent, maxYExtent])
                 .range([parseInt(selection.style('height'), 10), 0]);
 
-            sc.util.applyZoom(selection, data, dispatch, domain);
+            selection.call(sc.util.boundedZoom, dispatch);
 
             selection.datum(data)
                 .call(macd);

--- a/src/assets/js/chart/navChart.js
+++ b/src/assets/js/chart/navChart.js
@@ -22,9 +22,9 @@
 
         function navChart(selection) {
             var data = selection.datum().data;
-            var viewDomain = selection.datum().viewDomain;
+            var domain = selection.datum().domain;
 
-            viewScale.domain(viewDomain)
+            viewScale.domain(domain)
                 .range([0, parseInt(selection.style('width'), 10)]);
 
             var yExtent = fc.util.extent(sc.util.filterDataInDateRange(data,

--- a/src/assets/js/chart/primaryChart.js
+++ b/src/assets/js/chart/primaryChart.js
@@ -77,7 +77,7 @@
             var data = selection.datum().data;
             var domain = selection.datum().domain;
 
-            var currentBufferPeriod = currentSeries.buffer ? selection.datum().dataPeriod : 0;
+            var currentBufferPeriod = currentSeries.buffer ? selection.datum().period : 0;
             var paddedDomain = sc.util.paddedExtent(domain, currentBufferPeriod);
             timeSeries.xDomain(paddedDomain);
 

--- a/src/assets/js/chart/primaryChart.js
+++ b/src/assets/js/chart/primaryChart.js
@@ -123,7 +123,7 @@
             timeSeries.plotArea(multi);
             selection.call(timeSeries);
 
-            sc.util.applyZoom(selection, data, dispatch, domain);
+            selection.call(sc.util.boundedZoom, dispatch);
         }
 
         d3.rebind(primaryChart, dispatch, 'on');

--- a/src/assets/js/chart/rsiChart.js
+++ b/src/assets/js/chart/rsiChart.js
@@ -16,7 +16,7 @@
             var data = selection.datum().data;
             var domain = selection.datum().domain;
 
-            var currentBufferPeriod = selection.datum().displayBuffer ? selection.datum().dataPeriod : 0;
+            var currentBufferPeriod = selection.datum().displayBuffer ? selection.datum().period : 0;
             var paddedDomain = sc.util.paddedExtent(domain, currentBufferPeriod);
 
             rsi.xScale()

--- a/src/assets/js/chart/rsiChart.js
+++ b/src/assets/js/chart/rsiChart.js
@@ -14,23 +14,20 @@
 
         function rsiChart(selection) {
             var data = selection.datum().data;
-            var viewDomain = selection.datum().viewDomain;
+            var domain = selection.datum().domain;
+
+            var currentBufferPeriod = selection.datum().displayBuffer ? selection.datum().dataPeriod : 0;
+            var paddedDomain = sc.util.paddedExtent(domain, currentBufferPeriod);
 
             rsi.xScale()
-                .domain(viewDomain)
+                .domain(paddedDomain)
                 .range([0, parseInt(selection.style('width'), 10)]);
             rsi.yScale().range([parseInt(selection.style('height'), 10), 0]);
 
             rsiAlgorithm(data);
 
-            var zoom = d3.behavior.zoom();
-            zoom.x(rsi.xScale())
-                .on('zoom', function() {
-                    sc.util.zoomControl(zoom, selection, data, rsi.xScale());
-                    dispatch.viewChange(rsi.xScale().domain());
-                });
+            sc.util.applyZoom(selection, data, dispatch, domain);
 
-            selection.call(zoom);
             selection.datum(data)
                 .call(rsi);
         }

--- a/src/assets/js/chart/rsiChart.js
+++ b/src/assets/js/chart/rsiChart.js
@@ -26,7 +26,7 @@
 
             rsiAlgorithm(data);
 
-            sc.util.applyZoom(selection, data, dispatch, domain);
+            selection.call(sc.util.boundedZoom, dispatch);
 
             selection.datum(data)
                 .call(rsi);

--- a/src/assets/js/chart/xAxisChart.js
+++ b/src/assets/js/chart/xAxisChart.js
@@ -13,9 +13,8 @@
 
         function xAxisChart(selection) {
             var data = selection.datum().data;
-            var viewDomain = selection.datum().viewDomain;
-
-            var zoom = d3.behavior.zoom();
+            var currentBufferPeriod = selection.datum().displayBuffer ? selection.datum().period : 0;
+            var paddedDomain = sc.util.paddedExtent(selection.datum().domain, currentBufferPeriod);
 
             // Redraw
             var xAxisContainer = selection.selectAll('g.x-axis')
@@ -34,18 +33,11 @@
             selection.layout();
 
             xScale.range([0, xAxisContainer.layout('width')])
-                .domain(viewDomain);
+                .domain(paddedDomain);
+
+            selection.call(sc.util.boundedZoom, dispatch);
 
             xAxisContainer.call(xAxis);
-
-            // Behaves oddly if not reinitialized every render
-            zoom.x(xScale)
-                .on('zoom', function() {
-                    sc.util.zoomControl(zoom, selection, data, xScale);
-                    dispatch.viewChange(xScale.domain());
-                });
-
-            selection.call(zoom);
         }
 
         d3.rebind(xAxisChart, dispatch, 'on');

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -42,7 +42,7 @@
     }
 
     function onViewChanged(domain) {
-        dataModel.viewDomain = [domain[0], domain[1]];
+        dataModel.domain = [domain[0], domain[1]];
         render();
     }
 
@@ -83,7 +83,7 @@
 
     var mainMenu = sc.menu.main()
         .on('primaryChartSeriesChange', function(series) {
-            primaryChart.changeSeries(series.option);
+            primaryChart.changeSeries(series);
             /* Elements are drawn in the order they appear in the HTML - at this minute,
             D3FC doesn't maintain the ordering of elements, so it's easiest to just
             remove them and re-write them to the DOM in the correct order. */
@@ -92,7 +92,7 @@
             render();
         })
         .on('primaryChartIndicatorChange', function(indicator) {
-            primaryChart.changeIndicator(indicator.option);
+            primaryChart.changeIndicator(indicator);
             svgPrimary.selectAll('.multi')
                 .remove();
             render();

--- a/src/assets/js/menu/option.js
+++ b/src/assets/js/menu/option.js
@@ -1,10 +1,11 @@
 (function(d3, fc) {
     'use strict';
-    sc.menu.option = function(displayString, valueString, option) {
+    sc.menu.option = function(displayString, valueString, option, buffer) {
         return {
             displayString: displayString,
             valueString: valueString,
-            option: option
+            option: option,
+            buffer: buffer
         };
     };
 

--- a/src/assets/js/menu/primaryChart/series.js
+++ b/src/assets/js/menu/primaryChart/series.js
@@ -5,12 +5,12 @@
 
         var dispatch = d3.dispatch('primaryChartSeriesChange');
 
-        var candlestick = sc.menu.option('Candlestick', 'candlestick', fc.series.candlestick());
-        var ohlc = sc.menu.option('OHLC', 'ohlc', fc.series.ohlc());
-        var line = sc.menu.option('Line', 'line', fc.series.line());
+        var candlestick = sc.menu.option('Candlestick', 'candlestick', sc.series.candlestick(), true);
+        var ohlc = sc.menu.option('OHLC', 'ohlc', fc.series.ohlc(), true);
+        var line = sc.menu.option('Line', 'line', fc.series.line(), false);
         line.option.isLine = true;
-        var point = sc.menu.option('Point', 'point', fc.series.point());
-        var area = sc.menu.option('Area', 'area', fc.series.area());
+        var point = sc.menu.option('Point', 'point', fc.series.point(), true);
+        var area = sc.menu.option('Area', 'area', fc.series.area(), false);
 
         var options = sc.menu.generator.buttonGroup()
             .on('optionChange', function(series) {

--- a/src/assets/js/util/applyZoom.js
+++ b/src/assets/js/util/applyZoom.js
@@ -1,0 +1,16 @@
+(function(d3, fc, sc) {
+    'use strict';
+    sc.util.applyZoom = function(selection, data, dispatch, domain) {
+        var collisionScale = fc.scale.dateTime()
+            .domain(domain)
+            .range([0, parseInt(selection.attr('width'), 10)]);
+        var zoom = d3.behavior.zoom();
+        zoom.x(collisionScale)
+            .on('zoom', function() {
+                sc.util.zoomControl(zoom, selection, data, collisionScale);
+                dispatch.viewChange(collisionScale.domain());
+            });
+
+        selection.call(zoom);
+    };
+})(d3, fc, sc);

--- a/src/assets/js/util/boundedZoom.js
+++ b/src/assets/js/util/boundedZoom.js
@@ -1,7 +1,6 @@
 (function(d3, fc, sc) {
     'use strict';
     sc.util.boundedZoom = function(selection, dispatch) {
-        console.log(selection);
         var collisionScale = fc.scale.dateTime()
             .domain(selection.datum().domain)
             .range([0, parseInt(selection.attr('width'), 10)]);

--- a/src/assets/js/util/boundedZoom.js
+++ b/src/assets/js/util/boundedZoom.js
@@ -1,13 +1,14 @@
 (function(d3, fc, sc) {
     'use strict';
-    sc.util.applyZoom = function(selection, data, dispatch, domain) {
+    sc.util.boundedZoom = function(selection, dispatch) {
+        console.log(selection);
         var collisionScale = fc.scale.dateTime()
-            .domain(domain)
+            .domain(selection.datum().domain)
             .range([0, parseInt(selection.attr('width'), 10)]);
         var zoom = d3.behavior.zoom();
         zoom.x(collisionScale)
             .on('zoom', function() {
-                sc.util.zoomControl(zoom, selection, data, collisionScale);
+                sc.util.zoomControl(zoom, selection, selection.datum().data, collisionScale);
                 dispatch.viewChange(collisionScale.domain());
             });
 

--- a/src/assets/js/util/paddedExtent.js
+++ b/src/assets/js/util/paddedExtent.js
@@ -1,0 +1,13 @@
+(function(d3, fc) {
+    'use strict';
+    sc.util.paddedExtent = function(extent, period) {
+        // Adds a buffer of period to either side of data
+        // Create new variable so we don't change the argument
+        var paddedExtent = [extent[0], extent[1]];
+
+        paddedExtent[0] = d3.time.second.offset(new Date(extent[0]), -period);
+        paddedExtent[1] = d3.time.second.offset(new Date(extent[1]), +period);
+
+        return paddedExtent;
+    };
+})(d3, fc);


### PR DESCRIPTION
The primary chart now shows slightly more than the 'viewDomain', so the full candles can fit on the screen. The bufferPeriod can be set outside the chart and also turned since it's only needed for certain series types.