### PR TITLE
Bollinger Band moving average line hidden

### DIFF
--- a/src/assets/styles/base.less
+++ b/src/assets/styles/base.less
@@ -11,3 +11,7 @@
   margin-left: auto;
   margin-right: auto;
 }
+
+.average>path.line{
+  visibility: hidden;
+}

--- a/src/assets/styles/base.less
+++ b/src/assets/styles/base.less
@@ -11,7 +11,3 @@
   margin-left: auto;
   margin-right: auto;
 }
-
-.average>path.line{
-  visibility: hidden;
-}

--- a/src/assets/styles/plotArea.less
+++ b/src/assets/styles/plotArea.less
@@ -30,5 +30,9 @@
     fill: @candlestick-up-fill;
   }
 
+  .average>path.line{
+    visibility: hidden;
+  }
+
 }
 


### PR DESCRIPTION
Moving average line for Bollinger Bands has been hidden in CSS.
resolves #183