### PR TITLE
Revert "Update d3fc version"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/scottlogic/d3fc-showcase#readme",
   "dependencies": {
     "bootstrap": "^3.3.5",
-    "d3fc": "^1.0.0"
+    "d3fc": "^0.5.7"
   },
   "devDependencies": {
     "cordova": "^5.1.1",


### PR DESCRIPTION
Reverts ScottLogic/d3fc-showcase#212

Seems to be a bug in 1.0.0 - reverting until this is resolved.