### PR TITLE
Enable rotation on iOS app

### DIFF
--- a/mobile/config.xml
+++ b/mobile/config.xml
@@ -22,6 +22,7 @@
     <platform name="ios">
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
+        <preference name="Orientation" value="all" />
     </platform>
     <icon src="res/icon.png" />
     <preference name="DisallowOverscroll" value="true"/>


### PR DESCRIPTION
Some progress on #88.

Tested using the iOS emulator and an iPad 2.

(Also tested using the Android emulator and a Tesco Hudl (Android).)