### PR TITLE
Reduced horizontal padding on primary chart

### DIFF
--- a/src/assets/js/chart/primaryChart.js
+++ b/src/assets/js/chart/primaryChart.js
@@ -128,10 +128,11 @@
 
             // Scale y axis
             var yExtent = findTotalYExtent(visibleData, currentSeries, indicatorStrings);
-            // Add 10% either side of extreme high/lows
+            // Add padding either side of extreme high/lows
+            var percentagePadding = 0.04;
             var variance = yExtent[1] - yExtent[0];
-            yExtent[0] -= variance * 0.1;
-            yExtent[1] += variance * 0.1;
+            yExtent[0] -= variance * percentagePadding;
+            yExtent[1] += variance * percentagePadding;
             timeSeries.yDomain(yExtent);
 
             // Find current tick values and add close price to this list, then set it explicitly below


### PR DESCRIPTION
Reduces horizontal padding from 10% either side to 4% either side, in reference to Rob's comments in the sprint demo.