### PR TITLE
Centralise events, refactor models for components, create secondary chart component

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,6 +14,7 @@ module.exports = function(grunt) {
             ],
             srcJsFiles: [
                 'src/assets/js/sc.js',
+                'src/assets/js/event.js',
                 'src/assets/js/model/**/*.js',
                 'src/assets/js/chart/**/*.js',
                 'src/assets/js/menu/**/*.js',

--- a/src/assets/js/chart/macd.js
+++ b/src/assets/js/chart/macd.js
@@ -2,74 +2,40 @@
     'use strict';
 
     sc.chart.macd = function() {
-        var yAxisWidth = 45;
-
-        var dispatch = d3.dispatch('viewChange');
-
-        var xScale = fc.scale.dateTime();
-
-        var macdChart = fc.chart.cartesianChart(xScale, d3.scale.linear())
-            .xTicks(0)
-            .yOrient('right')
-            .margin({
-                top: 0,
-                left: 0,
-                bottom: 0,
-                right: yAxisWidth
-            });
-
-        var zero = fc.annotation.line()
+        var dispatch = d3.dispatch(sc.event.viewChange);
+        var zeroLine = fc.annotation.line()
             .value(0)
             .label('');
-        var macdRenderer = fc.indicator.renderer.macd();
-        var multi = fc.series.multi()
-            .series([zero, macdRenderer])
+        var renderer = fc.indicator.renderer.macd();
+        var algorithm = fc.indicator.algorithm.macd();
+
+        var chart = sc.chart.secondary()
+            .series([zeroLine, renderer])
             .mapping(function(series) {
-                if (series === zero) {
-                    return [0];
-                }
-                return this.data;
+                return series === zeroLine ? [0] : this;
             })
             .decorate(function(g) {
                 g.enter()
                     .attr('class', function(d, i) {
                         return ['multi zero', 'multi'][i];
                     });
+            })
+            .on(sc.event.viewChange, function(domain) {
+                dispatch[sc.event.viewChange](domain);
             });
-
-        var createForeground = sc.chart.foreground()
-            .rightMargin(yAxisWidth);
-
-        var macdAlgorithm = fc.indicator.algorithm.macd();
 
         function macd(selection) {
             var model = selection.datum();
+            algorithm(model.data);
 
-            macdAlgorithm(model.data);
-
-            macdChart.xDomain(model.viewDomain);
-
-            // Add percentage padding either side of extreme high/lows
-            var maxYExtent = d3.max(model.data, function(d) {
-                return Math.abs(d.macd.macd);
-            });
+            var maxYExtent = d3.max(model.data, function(d) { return Math.abs(d.macd.macd); });
             var paddedYExtent = sc.util.domain.padYDomain([-maxYExtent, maxYExtent], 0.04);
-            macdChart.yDomain(paddedYExtent);
+            chart.trackingLatest(model.trackingLatest)
+                .xDomain(model.viewDomain)
+                .yDomain(paddedYExtent);
 
-            // Redraw
-            macdChart.plotArea(multi);
-            selection.call(macdChart);
-
-            selection.call(createForeground);
-            var foreground = selection.select('rect.foreground');
-
-            var zoom = sc.behavior.zoom()
-                .scale(xScale)
-                .trackingLatest(selection.datum().trackingLatest)
-                .on('zoom', function(domain) {
-                    dispatch.viewChange(domain);
-                });
-            foreground.call(zoom);
+            selection.datum(model.data)
+                .call(chart);
         }
 
         d3.rebind(macd, dispatch, 'on');

--- a/src/assets/js/chart/nav.js
+++ b/src/assets/js/chart/nav.js
@@ -2,7 +2,7 @@
     'use strict';
 
     sc.chart.nav = function() {
-        var dispatch = d3.dispatch('viewChange');
+        var dispatch = d3.dispatch(sc.event.viewChange);
 
         var navChart = fc.chart.cartesianChart(fc.scale.dateTime(), d3.scale.linear())
             .yTicks(0)
@@ -46,12 +46,12 @@
 
             brush.on('brush', function() {
                 if (brush.extent()[0][0] - brush.extent()[1][0] !== 0) {
-                    dispatch.viewChange([brush.extent()[0][0], brush.extent()[1][0]]);
+                    dispatch[sc.event.viewChange]([brush.extent()[0][0], brush.extent()[1][0]]);
                 }
             })
             .on('brushend', function() {
                 if (brush.extent()[0][0] - brush.extent()[1][0] === 0) {
-                    dispatch.viewChange(sc.util.domain.centerOnDate(viewScale.domain(),
+                    dispatch[sc.event.viewChange](sc.util.domain.centerOnDate(viewScale.domain(),
                         model.data, brush.extent()[0][0]));
                 }
             });
@@ -62,10 +62,10 @@
             // Allow to zoom using mouse, but disable panning
             var zoom = sc.behavior.zoom()
                 .scale(viewScale)
-                .trackingLatest(selection.datum().trackingLatest)
+                .trackingLatest(model.trackingLatest)
                 .allowPan(false)
                 .on('zoom', function(domain) {
-                    dispatch.viewChange(domain);
+                    dispatch[sc.event.viewChange](domain);
                 });
 
             selection.call(zoom);

--- a/src/assets/js/chart/rsi.js
+++ b/src/assets/js/chart/rsi.js
@@ -2,57 +2,28 @@
     'use strict';
 
     sc.chart.rsi = function() {
-        var yAxisWidth = 45;
+        var dispatch = d3.dispatch(sc.event.viewChange);
+        var renderer = fc.indicator.renderer.relativeStrengthIndex();
+        var algorithm = fc.indicator.algorithm.relativeStrengthIndex();
+        var tickValues = [renderer.lowerValue(), 50, renderer.upperValue()];
 
-        var dispatch = d3.dispatch('viewChange');
-
-        var rsiRenderer = fc.indicator.renderer.relativeStrengthIndex();
-        var multi = fc.series.multi()
-            .series([rsiRenderer])
-            .mapping(function() { return this.data; });
-
-        var tickValues = [rsiRenderer.lowerValue(), 50, rsiRenderer.upperValue()];
-
-        var xScale = fc.scale.dateTime();
-
-        var rsiChart = fc.chart.cartesianChart(xScale, d3.scale.linear())
-            .xTicks(0)
-            .yOrient('right')
+        var chart = sc.chart.secondary()
+            .series([renderer])
             .yTickValues(tickValues)
-            .margin({
-                top: 0,
-                left: 0,
-                bottom: 0,
-                right: yAxisWidth
+            .on(sc.event.viewChange, function(domain) {
+                dispatch[sc.event.viewChange](domain);
             });
-
-        var createForeground = sc.chart.foreground()
-            .rightMargin(yAxisWidth);
-
-        var rsiAlgorithm = fc.indicator.algorithm.relativeStrengthIndex();
 
         function rsi(selection) {
             var model = selection.datum();
+            algorithm(model.data);
 
-            rsiAlgorithm(model.data);
-
-            rsiChart.xDomain(model.viewDomain)
+            chart.trackingLatest(model.trackingLatest)
+                .xDomain(model.viewDomain)
                 .yDomain([0, 100]);
 
-            // Redraw
-            rsiChart.plotArea(multi);
-            selection.call(rsiChart);
-
-            selection.call(createForeground);
-            var foreground = selection.select('rect.foreground');
-
-            var zoom = sc.behavior.zoom()
-                .scale(xScale)
-                .trackingLatest(selection.datum().trackingLatest)
-                .on('zoom', function(domain) {
-                    dispatch.viewChange(domain);
-                });
-            foreground.call(zoom);
+            selection.datum(model.data)
+                .call(chart);
         }
 
         d3.rebind(rsi, dispatch, 'on');

--- a/src/assets/js/chart/secondary.js
+++ b/src/assets/js/chart/secondary.js
@@ -1,0 +1,59 @@
+(function(d3, fc, sc) {
+    'use strict';
+
+    sc.chart.secondary = function() {
+        var dispatch = d3.dispatch(sc.event.viewChange);
+        var xScale = fc.scale.dateTime();
+        var yScale = d3.scale.linear();
+        var trackingLatest = true;
+        var yAxisWidth = 45;
+
+        var foreground = sc.chart.foreground()
+            .rightMargin(yAxisWidth);
+
+        var multi = fc.series.multi();
+        var chart = fc.chart.cartesianChart(xScale, yScale)
+            .plotArea(multi)
+            .xTicks(0)
+            .yOrient('right')
+            .margin({
+                top: 0,
+                left: 0,
+                bottom: 0,
+                right: yAxisWidth
+            });
+
+        function secondary(selection) {
+            selection.each(function(data) {
+                var container = d3.select(this)
+                    .call(chart)
+                    .call(foreground);
+
+                var zoom = sc.behavior.zoom()
+                    .scale(xScale)
+                    .trackingLatest(trackingLatest)
+                    .on('zoom', function(domain) {
+                        dispatch[sc.event.viewChange](domain);
+                    });
+
+                container.select('rect.foreground')
+                    .datum({data: selection.datum()})
+                    .call(zoom);
+            });
+        }
+
+        secondary.trackingLatest = function(x) {
+            if (!arguments.length) {
+                return trackingLatest;
+            }
+            trackingLatest = x;
+            return secondary;
+        };
+
+        d3.rebind(secondary, dispatch, 'on');
+        d3.rebind(secondary, multi, 'series', 'mapping', 'decorate');
+        d3.rebind(secondary, chart, 'yTickValues', 'yTickFormat', 'xDomain', 'yDomain');
+
+        return secondary;
+    };
+})(d3, fc, sc);

--- a/src/assets/js/data/dataInterface.js
+++ b/src/assets/js/data/dataInterface.js
@@ -6,7 +6,7 @@
         var callbackGenerator = sc.data.callbackInvalidator();
         var ohlcConverter = sc.data.feed.coinbase.ohlcWebSocketAdaptor();
         var dataGenerator = fc.data.random.financial();
-        var dispatch = d3.dispatch('messageReceived', 'dataLoaded');
+        var dispatch = d3.dispatch(sc.event.messageReceived, sc.event.dataLoaded);
         var candlesOfData = 200;
 
         function updateHistoricFeedDateRangeToPresent(period) {
@@ -29,7 +29,7 @@
                 if (socketEvent.type === 'message' && latestBasket) {
                     newBasketReceived(latestBasket, data);
                 }
-                dispatch.messageReceived(socketEvent, data);
+                dispatch[sc.event.messageReceived](socketEvent, data);
             };
         }
 
@@ -44,7 +44,7 @@
                     currentData = data.reverse();
                     ohlcConverter(liveCallback(currentData), currentData[currentData.length - 1]);
                 }
-                dispatch.dataLoaded(err, currentData);
+                dispatch[sc.event.dataLoaded](err, currentData);
             }));
         }
 
@@ -57,7 +57,7 @@
             dataGenerator.startDate(new Date(now - (candlesOfData - 1) * millisecondsPerDay));
 
             var dataGenerated = dataGenerator(candlesOfData);
-            dispatch.dataLoaded(null, dataGenerated);
+            dispatch[sc.event.dataLoaded](null, dataGenerated);
         };
 
         dataInterface.invalidate = function() {

--- a/src/assets/js/event.js
+++ b/src/assets/js/event.js
@@ -1,0 +1,19 @@
+(function(d3, fc, sc) {
+    'use strict';
+
+    sc.event = {
+        crosshairChange: 'crosshairChange',
+        viewChange: 'viewChange',
+        messageReceived: 'messageReceived',
+        dataLoaded: 'dataLoaded',
+        dataProductChange: 'dataProductChange',
+        dataPeriodChange: 'dataPeriodChange',
+        resetToLatest: 'resetToLatest',
+        toggleSlideout: 'toggleSlideout',
+        primaryChartSeriesChange: 'primaryChartSeriesChange',
+        primaryChartYValueAccessorChange: 'primaryChartYValueAccessorChange',
+        primaryChartIndicatorChange: 'primaryChartIndicatorChange',
+        secondaryChartChange: 'secondaryChartChange'
+    };
+
+})(d3, fc, sc);

--- a/src/assets/js/menu/head.js
+++ b/src/assets/js/menu/head.js
@@ -3,10 +3,11 @@
 
     sc.menu.head = function() {
 
-        var dispatch = d3.dispatch('resetToLive',
-            'toggleSlideout',
-            'dataProductChange',
-            'dataPeriodChange');
+        var dispatch = d3.dispatch(
+            sc.event.resetToLatest,
+            sc.event.toggleSlideout,
+            sc.event.dataProductChange,
+            sc.event.dataPeriodChange);
 
         function setPeriodChangeVisibility(visible) {
             var visibility = visible ? 'visible' : 'hidden';
@@ -17,13 +18,13 @@
         var dataProductDropdown = sc.menu.group()
             .generator(sc.menu.generator.dropdownGroup())
             .on('optionChange', function(product) {
-                dispatch.dataProductChange(product);
+                dispatch[sc.event.dataProductChange](product);
             });
 
         var dataPeriodDropdown = sc.menu.group()
             .generator(sc.menu.generator.dropdownGroup())
             .on('optionChange', function(period) {
-                dispatch.dataPeriodChange(period);
+                dispatch[sc.event.dataPeriodChange](period);
             });
 
         function configureDropdown() {
@@ -46,11 +47,11 @@
                     .call(dataPeriodDropdown);
                 selection.select('#reset-button')
                     .on('click', function() {
-                        dispatch.resetToLive();
+                        dispatch[sc.event.resetToLatest]();
                     });
                 selection.select('#toggle-button')
                     .on('click', function() {
-                        dispatch.toggleSlideout();
+                        dispatch[sc.event.toggleSlideout]();
                     });
             });
         };

--- a/src/assets/js/menu/side.js
+++ b/src/assets/js/menu/side.js
@@ -3,10 +3,11 @@
 
     sc.menu.side = function() {
 
-        var dispatch = d3.dispatch('primaryChartSeriesChange',
-            'primaryChartYValueAccessorChange',
-            'primaryChartIndicatorChange',
-            'secondaryChartChange');
+        var dispatch = d3.dispatch(
+            sc.event.primaryChartSeriesChange,
+            sc.event.primaryChartYValueAccessorChange,
+            sc.event.primaryChartIndicatorChange,
+            sc.event.secondaryChartChange);
 
         var candlestick = sc.menu.option('Candlestick', 'candlestick', sc.series.candlestick());
         var ohlc = sc.menu.option('OHLC', 'ohlc', fc.series.ohlc());
@@ -19,7 +20,7 @@
             .formOptionListFromCollection([candlestick, ohlc, line, point, area], fc.util.fn.identity)
             .generator(sc.menu.generator.buttonGroup())
             .on('optionChange', function(series) {
-                dispatch.primaryChartSeriesChange(series);
+                dispatch[sc.event.primaryChartSeriesChange](series);
             });
 
         var open = sc.menu.option('Open', 'open', function(d) { return d.open; });
@@ -31,7 +32,7 @@
             .formOptionListFromCollection([open, high, low, close], fc.util.fn.identity)
             .generator(sc.menu.generator.buttonGroup(3))
             .on('optionChange', function(yValueAccessor) {
-                dispatch.primaryChartYValueAccessorChange(yValueAccessor);
+                dispatch[sc.event.primaryChartYValueAccessorChange](yValueAccessor);
             });
 
         var movingAverage = fc.series.line()
@@ -48,7 +49,7 @@
             .formOptionListFromCollection([movingAverageIndicator, bollingerIndicator], fc.util.fn.identity)
             .generator(sc.menu.generator.toggleGroup())
             .on('optionChange', function(indicator) {
-                dispatch.primaryChartIndicatorChange(indicator);
+                dispatch[sc.event.primaryChartIndicatorChange](indicator);
             });
 
         var rsi = sc.menu.option('RSI', 'secondary-rsi', sc.chart.rsi());
@@ -59,7 +60,7 @@
             .formOptionListFromCollection([rsi, macd, volume], fc.util.fn.identity)
             .generator(sc.menu.generator.toggleGroup())
             .on('optionChange', function(chart) {
-                dispatch.secondaryChartChange(chart);
+                dispatch[sc.event.secondaryChartChange](chart);
             });
 
         var side = function(selection) {

--- a/src/assets/js/model/nav.js
+++ b/src/assets/js/model/nav.js
@@ -1,0 +1,12 @@
+(function(d3, fc, sc) {
+    'use strict';
+
+    sc.model.nav = function() {
+        return {
+            data: [],
+            viewDomain: [],
+            trackingLatest: true
+        };
+    };
+
+})(d3, fc, sc);

--- a/src/assets/js/model/primaryChart.js
+++ b/src/assets/js/model/primaryChart.js
@@ -1,0 +1,15 @@
+(function(d3, fc, sc) {
+    'use strict';
+
+    sc.model.primaryChart = function() {
+        return {
+            data: [],
+            trackingLatest: true,
+            viewDomain: [],
+            series: sc.menu.option('Candlestick', 'candlestick', sc.series.candlestick()),
+            yValueAccessor: {option: function(d) { return d.close; }},
+            indicators: []
+        };
+    };
+
+})(d3, fc, sc);

--- a/src/assets/js/model/secondaryChart.js
+++ b/src/assets/js/model/secondaryChart.js
@@ -1,0 +1,12 @@
+(function(d3, fc, sc) {
+    'use strict';
+
+    sc.model.secondaryChart = function() {
+        return {
+            data: [],
+            viewDomain: [],
+            trackingLatest: true
+        };
+    };
+
+})(d3, fc, sc);

--- a/src/assets/js/model/xAxis.js
+++ b/src/assets/js/model/xAxis.js
@@ -1,0 +1,10 @@
+(function(d3, fc, sc) {
+    'use strict';
+
+    sc.model.xAxis = function() {
+        return {
+            viewDomain: []
+        };
+    };
+
+})(d3, fc, sc);


### PR DESCRIPTION
We have two types of renderers:

+ Components (follow the standard component pattern); data is bound to the selection passed to them and configuration is set using methods on the component
+ Views (are composed of components); both data and configuration properties are bound to the selection passed to them, there are no methods for configuration

https://github.com/ScottLogic/d3fc-showcase/commit/b8d21c337a58a8476b2425c7a1c624539471d980 separates the views into their own namespace - is this a more logical/intuitive grouping?