### PR TITLE
Fixes potential bug in close price line calculation

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -137,7 +137,7 @@
             secondaryChartModel.data = data;
             navModel.data = data;
             // TODO: probably only want to update this if the user isn't already mousing over with the crosshair
-            legendModel.data = data[data.length - 1];
+            legendModel.data = sc.util.latestData(data)[0];
         }
 
         function updateModelSelectedProduct(product) {

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -137,7 +137,7 @@
             secondaryChartModel.data = data;
             navModel.data = data;
             // TODO: probably only want to update this if the user isn't already mousing over with the crosshair
-            legendModel.data = sc.util.latestData(data)[0];
+            legendModel.data = sc.util.latestData(data);
         }
 
         function updateModelSelectedProduct(product) {

--- a/src/assets/js/chart/primary.js
+++ b/src/assets/js/chart/primary.js
@@ -106,7 +106,7 @@
             .mapping(function(series) {
                 switch (series) {
                     case closeLine:
-                        return [this.data[this.data.length - 1]];
+                        return sc.util.latestData(this.data);
                     case crosshair:
                         return crosshairData;
                     default:
@@ -177,13 +177,13 @@
             primaryChart.yDomain(paddedYExtent);
 
             // Find current tick values and add close price to this list, then set it explicitly below
-            var latestPrice = currentYValueAccessor(model.data[model.data.length - 1]);
-            var tickValues = produceAnnotatedTickValues(yScale, [latestPrice]);
+            var latestPrice = sc.util.latestData(model.data).map(function(d) { return currentYValueAccessor(d); });
+            var tickValues = produceAnnotatedTickValues(yScale, latestPrice);
             primaryChart.yTickFormat(model.product.priceFormat)
                 .yTickValues(tickValues)
                 .yDecorate(function(s) {
                     s.selectAll('.tick')
-                        .filter(function(d) { return d === latestPrice; })
+                        .filter(function(d) { return latestPrice.indexOf(d) !== -1; })
                         .classed('closeLine', true)
                         .select('path')
                         .attr('d', function(d) {

--- a/src/assets/js/chart/primary.js
+++ b/src/assets/js/chart/primary.js
@@ -177,13 +177,13 @@
             primaryChart.yDomain(paddedYExtent);
 
             // Find current tick values and add close price to this list, then set it explicitly below
-            var latestPrice = sc.util.latestData(model.data).map(function(d) { return currentYValueAccessor(d); });
-            var tickValues = produceAnnotatedTickValues(yScale, latestPrice);
+            var latestPrice = currentYValueAccessor(sc.util.latestData(model.data));
+            var tickValues = produceAnnotatedTickValues(yScale, [latestPrice]);
             primaryChart.yTickFormat(model.product.priceFormat)
                 .yTickValues(tickValues)
                 .yDecorate(function(s) {
                     s.selectAll('.tick')
-                        .filter(function(d) { return latestPrice.indexOf(d) !== -1; })
+                        .filter(function(d) { return d === latestPrice; })
                         .classed('closeLine', true)
                         .select('path')
                         .attr('d', function(d) {

--- a/src/assets/js/util/domain/padTimeExtent.js
+++ b/src/assets/js/util/domain/padTimeExtent.js
@@ -1,0 +1,29 @@
+(function(d3, fc, sc) {
+    'use strict';
+
+    function domainBeforeStartOfData(domain, data) {
+        var earliestViewedTime = domain[0].getTime();
+        var earliestDatumTime = data[0].date.getTime();
+        return earliestViewedTime <= earliestDatumTime;
+    }
+
+    function domainAfterEndOfData(domain, data) {
+        var latestViewedTime = domain[1].getTime();
+        var lastDatumTime = data[data.length - 1].date.getTime();
+        return latestViewedTime >= lastDatumTime;
+    }
+
+    sc.util.domain.padTimeExtent = function(domain, data, padding) {
+        // Adds a padding of period to ends of domain
+        var paddedDomain = domain;
+
+        if (domainBeforeStartOfData(domain, data)) {
+            paddedDomain[0] = d3.time.second.offset(new Date(domain[0]), -padding);
+        }
+        if (domainAfterEndOfData(domain, data)) {
+            paddedDomain[1] = d3.time.second.offset(new Date(domain[1]), +padding);
+        }
+
+        return paddedDomain;
+    };
+})(d3, fc, sc);

--- a/src/assets/js/util/latestData.js
+++ b/src/assets/js/util/latestData.js
@@ -3,6 +3,6 @@
 
     sc.util.latestData = function(data) {
         var latestDataTime = fc.util.extent(data, 'date')[1];
-        return data.filter(function(d) { return d.date.getTime() === latestDataTime.getTime(); });
+        return data.filter(function(d) { return d.date.getTime() === latestDataTime.getTime(); })[0];
     };
 })(d3, fc, sc);

--- a/src/assets/js/util/latestData.js
+++ b/src/assets/js/util/latestData.js
@@ -1,0 +1,8 @@
+(function(d3, fc, sc) {
+    'use strict';
+
+    sc.util.latestData = function(data) {
+        var latestDataTime = fc.util.extent(data, 'date')[1];
+        return data.filter(function(d) { return d.date.getTime() === latestDataTime.getTime(); });
+    };
+})(d3, fc, sc);

--- a/test/util/latestDataSpec.js
+++ b/test/util/latestDataSpec.js
@@ -23,43 +23,18 @@
             shuffledData = [obj(thursday), obj(wednesday), obj(monday), obj(friday), obj(tuesday)];
         });
 
-        it('should return a single latest data point in an array if it is unique', function() {
+        it('should return a single latest data point in an array', function() {
             var latestDatum = sc.util.latestData(data);
 
-            expect(latestDatum.length).toBe(1);
-            expect(latestDatum[0].date).toEqual(friday);
+            expect(latestDatum.date).toEqual(friday);
 
             var shuffledLatestDatum = sc.util.latestData(shuffledData);
 
-            expect(shuffledLatestDatum.length).toBe(1);
-            expect(shuffledLatestDatum[0].date).toEqual(friday);
+            expect(shuffledLatestDatum.date).toEqual(friday);
         });
 
-        it('should return the multiple latest data points in an array if there are more than one', function() {
-            // Set obj(friday) to obj(thursday) so there are multiple latest datums
-            data[4] = obj(thursday);
-
-            var latestDatum = sc.util.latestData(data);
-
-            expect(latestDatum.length).toBe(2);
-            expect(latestDatum[0].date).toEqual(thursday);
-            expect(latestDatum[1].date).toEqual(thursday);
-
-            // Set obj(friday) to obj(thursday) so there are multiple latest datums
-            shuffledData[3] = obj(thursday);
-
-            var shuffledLatestDatum = sc.util.latestData(shuffledData);
-
-            expect(shuffledLatestDatum.length).toBe(2);
-            expect(shuffledLatestDatum[0].date).toEqual(thursday);
-            expect(shuffledLatestDatum[1].date).toEqual(thursday);
-        });
-
-        it('should return an empty array if nothing is passed into the function', function() {
-            var emptyArray = sc.util.latestData([]);
-
-            expect(emptyArray.length).toBe(0);
-            expect(emptyArray).toEqual([]);
+        it('should return undefined if nothing is passed into the function', function() {
+            expect(sc.util.latestData([])).toBe(undefined);
         });
 
     });

--- a/test/util/latestDataSpec.js
+++ b/test/util/latestDataSpec.js
@@ -1,0 +1,66 @@
+(function(d3, fc, sc) {
+    'use strict';
+
+    describe('sc.util.latestData', function() {
+
+        function obj(val, price) {
+            return {
+                date: val
+            };
+        }
+
+        var data;
+        var shuffledData;
+
+        var monday = new Date(2015, 7, 17);
+        var tuesday = new Date(2015, 7, 18);
+        var wednesday = new Date(2015, 7, 19);
+        var thursday = new Date(2015, 7, 20);
+        var friday = new Date(2015, 7, 21);
+
+        beforeEach(function() {
+            data = [obj(monday), obj(tuesday), obj(wednesday), obj(thursday), obj(friday)];
+            shuffledData = [obj(thursday), obj(wednesday), obj(monday), obj(friday), obj(tuesday)];
+        });
+
+        it('should return a single latest data point in an array if it is unique', function() {
+            var latestDatum = sc.util.latestData(data);
+
+            expect(latestDatum.length).toBe(1);
+            expect(latestDatum[0].date).toEqual(friday);
+
+            var shuffledLatestDatum = sc.util.latestData(shuffledData);
+
+            expect(shuffledLatestDatum.length).toBe(1);
+            expect(shuffledLatestDatum[0].date).toEqual(friday);
+        });
+
+        it('should return the multiple latest data points in an array if there are more than one', function() {
+            // Set obj(friday) to obj(thursday) so there are multiple latest datums
+            data[4] = obj(thursday);
+
+            var latestDatum = sc.util.latestData(data);
+
+            expect(latestDatum.length).toBe(2);
+            expect(latestDatum[0].date).toEqual(thursday);
+            expect(latestDatum[1].date).toEqual(thursday);
+
+            // Set obj(friday) to obj(thursday) so there are multiple latest datums
+            shuffledData[3] = obj(thursday);
+
+            var shuffledLatestDatum = sc.util.latestData(shuffledData);
+
+            expect(shuffledLatestDatum.length).toBe(2);
+            expect(shuffledLatestDatum[0].date).toEqual(thursday);
+            expect(shuffledLatestDatum[1].date).toEqual(thursday);
+        });
+
+        it('should return an empty array if nothing is passed into the function', function() {
+            var emptyArray = sc.util.latestData([]);
+
+            expect(emptyArray.length).toBe(0);
+            expect(emptyArray).toEqual([]);
+        });
+
+    });
+})(d3, fc, sc);


### PR DESCRIPTION
Removes use of `data[data.length - 1]` to calculate latest data in close price line & annotation and for default crosshair display