### PR TITLE
Update Travis to build on Node 4.1 and not io.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: node_js
 node_js:
   - "0.12"
   - "4.0"
-  - "iojs"
+  - "4.1"
 before_install: npm install -g grunt-cli
 install: npm install
-matrix:
-  fast_finish: true
-  allow_failures: 
-  - node_js: "iojs"


### PR DESCRIPTION
Build on the latest version of Node and, as io.js has merged back in with Node, no longer run the build on io.js.