### PR TITLE
Crosshair updated to match UX designs

### DIFF
--- a/src/assets/js/chart/primary.js
+++ b/src/assets/js/chart/primary.js
@@ -171,6 +171,60 @@
             movingAverage(model.data);
             bollingerAlgorithm(model.data);
 
+            // Update the crosshair depending on the series displayed
+            if (currentSeries.valueString === 'candlestick' || currentSeries.valueString === 'ohlc') {
+                //If the candlestick or ohlc selected, updated the crosshair to add classes to reflect UX designs
+                selection.each(function(data) {
+                    var barWidth = fc.util.fractionalBarWidth(0.75);
+                    var xValue = function(d) { return d.date; };
+                    var xValueScaled = function(d, i) { return xScale(xValue(d, i)); };
+                    var width = (barWidth(data.data.map(xValueScaled))) + 2;
+
+                    crosshair.decorate(function(s) {
+                        s.enter()
+                            .selectAll('line')
+                            .classed('crosshairHidden', function() {
+                                if (this.hasAttribute('x2')) {
+                                    return true;
+                                } else if (this.hasAttribute('y2')) {
+                                    return false;
+                                }
+                            })
+                            .classed('crosshairShown', function() {
+                                if (this.hasAttribute('x2')) {
+                                    return false;
+                                } else if (this.hasAttribute('y2')) {
+                                    return true;
+                                }
+                            });
+
+                        s.selectAll('line')
+                            .style('stroke-width', function() {
+                            if (this.hasAttribute('y2')) {
+                                return width;
+                            }
+                        });
+
+                        s.enter()
+                            .select('.point')
+                            .style('visibility', 'hidden');
+                    });
+                });
+            } else {
+                // If line, point, or area series selected, remove the classes added
+                crosshair.decorate(function(s) {
+                    s.enter()
+                        .selectAll('line')
+                        .classed('crosshairHidden', false)
+                        .classed('crosshairShown', false)
+                        .style('stroke-width', '1px');
+
+                    s.enter()
+                        .select('.point')
+                        .style('visibility', 'shown');
+                });
+            }
+
             // Scale y axis
             var visibleData = sc.util.domain.filterDataInDateRange(primaryChart.xDomain(), model.data);
             var yExtent = findTotalYExtent(visibleData, currentSeries, currentIndicators);

--- a/src/assets/styles/crosshair.less
+++ b/src/assets/styles/crosshair.less
@@ -8,4 +8,11 @@
         fill-opacity: @crosshair-circle-opacity;
         stroke: darken(@crosshair-circle-colour, 20%);
     }
+  .crosshairHidden {
+    visibility: hidden;
+  }
+  .crosshairShown {
+    stroke: @crosshair-colour !important;     // Important avoids the tick mark css overwriting
+    stroke-dasharray: 0;
+  }
 }

--- a/src/assets/styles/variables.less
+++ b/src/assets/styles/variables.less
@@ -99,6 +99,7 @@
 @crosshair-line-colour: @tertiary-blue;
 @crosshair-circle-colour: @tertiary-blue;
 @crosshair-circle-opacity: 0.75;
+@crosshair-colour: fade(@primary-blue, 20%);
 
 // Legend
 @legend-background-colour: @background-colour;


### PR DESCRIPTION
Closes #321 

Updated the crosshair to match the UX designs for the candlestick view.
Currently left the crosshair the way it was previously done for all other views.