### PR TITLE
Update build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-contrib-jasmine": "^0.9.2",
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-less": "^1.1.0",
-    "grunt-contrib-uglify": "^0.10.1",
+    "grunt-contrib-uglify": "^0.11.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-cordovacli": "^0.8.2",
     "grunt-gh-pages": "^1.0.0",

--- a/src/index.html.tpl
+++ b/src/index.html.tpl
@@ -46,6 +46,12 @@
         </div>
     </div>
 </div>
+<% if (development) { %>
+<% _.forEach(developmentVendorJsFiles, function(filePath) {
+%><script src="<%- filePath %>"></script>
+<%
+}); %>
+<% } %>
 <script src="<%- appJsPath %>"></script>
 <%= liveReload === true ? '<script src="//localhost:35729/livereload.js"></script>' : '' %>
 </body>


### PR DESCRIPTION
**Faster builds!**

- Separate build and test tasks
- Update uglify
- Include vendor JS files directly in HTML for development build
- No longer use minified version of d3fc for our production build to stop key issue
- Only uglify our source files; use vendor min files in production build
- Remove check warn only task
- Include d3-legend dep for d3fc