### PR TITLE
Performance fix

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -13,7 +13,7 @@
             primary: chartsContainer.select('#primary-container'),
             secondaries: chartsContainer.selectAll('.secondary-container'),
             xAxis: chartsContainer.select('#x-axis-container'),
-            navbar: chartsContainer.select('#navbar-row'),
+            navbar: chartsContainer.select('#navbar-container'),
             legend: appContainer.select('#legend'),
             suspendLayout: function(value) {
                 var self = this;
@@ -62,6 +62,7 @@
         var sideMenuModel = sc.model.menu.side();
         var xAxisModel = sc.model.xAxis(day1);
         var navModel = sc.model.nav();
+        var navResetModel = sc.model.navigationReset();
         var headMenuModel = sc.model.headMenu([generated, bitcoin], generated, day1);
         var legendModel = sc.model.legend(generated, day1);
 
@@ -75,6 +76,7 @@
 
         var headMenu;
         var sideMenu;
+        var navReset;
 
         function renderInternal() {
             if (layoutRedrawnInNextRender) {
@@ -102,6 +104,10 @@
 
             containers.navbar.datum(navModel)
                 .call(charts.navbar);
+
+            containers.app.select('#navbar-reset')
+                .datum(navResetModel)
+                .call(navReset);
 
             containers.app.select('.head-menu')
                 .datum(headMenuModel)
@@ -146,6 +152,7 @@
             primaryChartModel.trackingLatest = trackingLatest;
             secondaryChartModel.trackingLatest = trackingLatest;
             navModel.trackingLatest = trackingLatest;
+            navResetModel.trackingLatest = trackingLatest;
             render();
         }
 
@@ -189,7 +196,11 @@
 
         function initialiseNav() {
             return sc.chart.nav()
-                .on(sc.event.viewChange, onViewChange)
+                .on(sc.event.viewChange, onViewChange);
+        }
+
+        function initialiseNavReset() {
+            return sc.menu.navigationReset()
                 .on(sc.event.resetToLatest, resetToLatest);
         }
 
@@ -293,6 +304,7 @@
             var dataInterface = initialiseDataInterface();
             headMenu = initialiseHeadMenu(dataInterface);
             sideMenu = initialiseSideMenu();
+            navReset = initialiseNavReset();
 
             updateLayout();
             initialiseResize();

--- a/src/assets/js/chart/nav.js
+++ b/src/assets/js/chart/nav.js
@@ -14,9 +14,7 @@
         var handleCircleCenter = borderWidth + barHeight / 2;
         var handleBarWidth = 2;
 
-        var dispatch = d3.dispatch(
-            sc.event.viewChange,
-            sc.event.resetToLatest);
+        var dispatch = d3.dispatch(sc.event.viewChange);
 
         var navChart = fc.chart.cartesian(fc.scale.dateTime(), d3.scale.linear())
             .yTicks(0)
@@ -74,23 +72,9 @@
         var layoutWidth;
 
         function nav(selection) {
-            var navbarContainer = selection.select('#navbar-container');
-            var navbarReset = selection.select('#navbar-reset');
-            var model = navbarContainer.datum();
+            var model = selection.datum();
 
             viewScale.domain(model.viewDomain);
-
-            var resetButton = navbarReset.selectAll('g')
-                .data([model]);
-
-            resetButton.enter()
-                .append('g')
-                .attr('class', 'reset-button')
-                .on('click', function() { dispatch[sc.event.resetToLatest](); })
-                .append('path')
-                .attr('d', 'M1.5 1.5h13.438L23 20.218 14.937 38H1.5l9.406-17.782L1.5 1.5z');
-
-            resetButton.classed('active', !model.trackingLatest);
 
             var filteredData = sc.util.domain.filterDataInDateRange(
                 fc.util.extent().fields('date')(model.data),
@@ -130,7 +114,7 @@
             });
 
             navChart.plotArea(navMulti);
-            navbarContainer.call(navChart);
+            selection.call(navChart);
 
             // Allow to zoom using mouse, but disable panning
             var zoom = sc.behavior.zoom(layoutWidth)
@@ -141,7 +125,7 @@
                     dispatch[sc.event.viewChange](domain);
                 });
 
-            navbarContainer.select('.plot-area')
+            selection.select('.plot-area')
                 .call(zoom);
         }
 

--- a/src/assets/js/menu/navigationReset.js
+++ b/src/assets/js/menu/navigationReset.js
@@ -1,0 +1,28 @@
+(function(d3, fc, sc) {
+    'use strict';
+
+    sc.menu.navigationReset = function() {
+
+        var dispatch = d3.dispatch(sc.event.resetToLatest);
+
+        function navReset(selection) {
+            var model = selection.datum();
+
+            var resetButton = selection.selectAll('g')
+                .data([model]);
+
+            resetButton.enter()
+                .append('g')
+                .attr('class', 'reset-button')
+                .on('click', function() { dispatch[sc.event.resetToLatest](); })
+                .append('path')
+                .attr('d', 'M1.5 1.5h13.438L23 20.218 14.937 38H1.5l9.406-17.782L1.5 1.5z');
+
+            resetButton.classed('active', !model.trackingLatest);
+        }
+
+        d3.rebind(navReset, dispatch, 'on');
+
+        return navReset;
+    };
+})(d3, fc, sc);

--- a/src/assets/js/model/navigationReset.js
+++ b/src/assets/js/model/navigationReset.js
@@ -1,0 +1,10 @@
+(function(d3, fc, sc) {
+    'use strict';
+
+    sc.model.navigationReset = function() {
+        return {
+            trackingLatest: true
+        };
+    };
+
+})(d3, fc, sc);


### PR DESCRIPTION
New navbar reset button implementation made a div become a container. I split the button to restore navbar-container as the container stored. This way the suspendLayout method applies, while it doesn't on divs.
This was resulting in a forced layout costing 0.6 ms