### PR TITLE
Set html and body height to 100% to prevent dropdown being cropped while loading screen is displayed

### DIFF
--- a/src/assets/styles/base.less
+++ b/src/assets/styles/base.less
@@ -6,6 +6,7 @@ html, body {
   font-family: @font-family;
   font-weight: @font-weight-base;
   line-height: @line-height-base;
+  height: 100%;
 }
 
 text {


### PR DESCRIPTION
Fixes #443 